### PR TITLE
selector - link opens in same tab for safari

### DIFF
--- a/src/democracys-library.ts
+++ b/src/democracys-library.ts
@@ -154,7 +154,7 @@ export class IaDemocracysLibrary extends LitElement {
 
   resourceSelected(e: Event): void {
     const url = (e?.target as HTMLSelectElement).value;
-    window.open(url, '_blank');
+    window.location.href = url;
   }
 
   render() {


### PR DESCRIPTION
Problem: Safari browser defaults to block pop ups so when selector option is picked, it looks like nothing happened.

Solution: open in same window.