### PR TITLE
header text overlays on pic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/democracys-library.ts
+++ b/src/democracys-library.ts
@@ -9,8 +9,8 @@ import './resources-highlights';
 import { carousel1, carousel1Title } from './data/carousel-1';
 import type { CarouselCard } from './data/carousel-1';
 import { didYouKnow, Factoid } from './data/did-you-know';
-import './ti-tle';
-import './arti-cle';
+import './dl-title';
+import './dl-article';
 import './header';
 import { resourceCardLink } from './data/resource-card-link';
 
@@ -62,11 +62,11 @@ export class IaDemocracysLibrary extends LitElement {
     return this.didYouKnow.map((fact: Factoid, i) => {
       const tintColor = (i % 2 === 0 ? 'yellow' : 'green') as string;
       return html`
-        <arti-cle>
+        <dl-article tabindex="0">
           <div class="title">
-            <ti-tle class=${tintColor}
-              ><span class="did-you-know-title">${fact.cardTitle}</span></ti-tle
-            >
+            <dl-title class=${tintColor}>
+              <h3 class="did-you-know-title">${fact.cardTitle}</h3>
+            </dl-title>
           </div>
           <p class="full-width" tabindex="0">${fact.details}</p>
           <div class="factoid-link">
@@ -86,16 +86,16 @@ export class IaDemocracysLibrary extends LitElement {
               >${fact.linkText}</a
             >
           </div>
-        </arti-cle>
+        </dl-article>
       `;
     });
   }
 
   resourceCard(card: card, tintColor: 'yellow' | 'green'): TemplateResult {
     return html`
-      <arti-cle tabindex="0">
+      <dl-article tabindex="0">
         <div class="title">
-          <ti-tle class=${tintColor ?? ''}>${card.title}</ti-tle>
+          <dl-title class=${tintColor ?? ''}><h3>${card.title}</h3></dl-title>
         </div>
         <a
           class="item-preview"
@@ -133,7 +133,7 @@ export class IaDemocracysLibrary extends LitElement {
           }}
           >Browse the ${card.collectionTitle}</a
         >
-      </arti-cle>
+      </dl-article>
     `;
   }
 
@@ -167,7 +167,7 @@ export class IaDemocracysLibrary extends LitElement {
 
   get topCarousel(): TemplateResult {
     return html`
-      <ti-tle class="green">${carousel1Title}</ti-tle>
+      <dl-title class="green"><h3>${carousel1Title}</h3></dl-title>
       <section id="carousel-1" class="carousel">
         ${this.carousel1.map((card, i) => {
           const tintColor = i % 2 === 0 ? 'yellow' : 'green';
@@ -232,9 +232,9 @@ export class IaDemocracysLibrary extends LitElement {
           ${this.factoids}
         </section>
         <resources-highlights class="one-col-margin">
-          <arti-cle>
+          <dl-article tabindex="0">
             <div class="title">
-              <ti-tle class="green">REGIONAL ORGANIZATIONS</ti-tle>
+              <dl-title class="green"><h3>REGIONAL ORGANIZATIONS</h3></dl-title>
             </div>
             <div class="map-img">
               <img
@@ -270,7 +270,7 @@ export class IaDemocracysLibrary extends LitElement {
                 >${resourceCardLink.linkText}</a
               >
             </div>
-          </arti-cle>
+          </dl-article>
           ${
             // eslint-disable-next-line arrow-body-style
             this.highlights.map((card, i: number) => {
@@ -294,6 +294,10 @@ export class IaDemocracysLibrary extends LitElement {
 
     :host(:focus) {
       outline: none;
+    }
+
+    h3 {
+      margin: 0;
     }
 
     a {

--- a/src/democracys-library.ts
+++ b/src/democracys-library.ts
@@ -298,6 +298,8 @@ export class IaDemocracysLibrary extends LitElement {
 
     h3 {
       margin: 0;
+      /** Teko is already bold, adding for safari's default styling */
+      font-weight: initial;
     }
 
     a {

--- a/src/dl-article.ts
+++ b/src/dl-article.ts
@@ -1,7 +1,7 @@
 import { html, css, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-@customElement('arti-cle')
+@customElement('dl-article')
 export class ArticleBlock extends LitElement {
   render() {
     return html`<slot></slot>`;

--- a/src/dl-title.ts
+++ b/src/dl-title.ts
@@ -1,16 +1,19 @@
 import { html, css, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-@customElement('ti-tle')
+@customElement('dl-title')
 export class TitleSection extends LitElement {
   render() {
     return html` <span><slot></slot></span> `;
   }
 
   static styles = css`
+    :host,
+    ::slotted(*) {
+      font-size: 2.5rem;
+    }
     :host {
       font-family: 'Teko', sans-serif;
-      font-size: 2.5rem;
       padding: 10px 10px 5px 0;
       background-repeat: no-repeat;
       background-size: cover;

--- a/src/header.ts
+++ b/src/header.ts
@@ -9,8 +9,8 @@ export class WelcomeHeader extends LitElement {
         <span class="celebration-title"
           >Welcome to Democracy's Library collection.</span
         >
-        <div class="left"></div>
         <div class="pic"></div>
+        <div class="left"></div>
         <div class="action-bar-section">
           <slot name="action-bar-section"></slot>
         </div>
@@ -47,14 +47,18 @@ export class WelcomeHeader extends LitElement {
     }
 
     .left {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 100%;
       background-repeat: no-repeat;
       height: 100%;
-      z-index: 1;
+      z-index: 2;
       background-image: url('https://archive.org/download/democracys-library/web-component/banner-text-2.svg');
     }
 
     .pic {
-      z-index: 2;
+      z-index: 1;
       position: absolute;
       top: 0px;
       bottom: 0px;

--- a/test/democracys-library.test.ts
+++ b/test/democracys-library.test.ts
@@ -63,7 +63,7 @@ describe('IaDemocracysLibrary', () => {
     const carouselContainer = sections?.[1];
     expect(carouselContainer).to.exist;
     // expect(carousel?.children).to.equal(33);
-    expect(carouselContainer?.children[0].tagName).to.equal('TI-TLE');
+    expect(carouselContainer?.children[0].tagName).to.equal('DL-TITLE');
     expect(carouselContainer?.children[0].innerHTML).to.contain(carousel1Title);
 
     expect(carouselContainer?.children[1].tagName).to.equal('SECTION');

--- a/test/ti-tle.test.ts
+++ b/test/ti-tle.test.ts
@@ -2,8 +2,8 @@
 /* eslint-disable no-useless-escape */
 import { html, fixture, expect } from '@open-wc/testing';
 
-import { TitleSection } from '../src/ti-tle';
-import '../src/ti-tle';
+import { TitleSection } from '../src/dl-title';
+import '../src/dl-title';
 
 describe('`<ti-tle>`, TitleSection', () => {
   it('Has specific styles', async () => {

--- a/test/ti-tle.test.ts
+++ b/test/ti-tle.test.ts
@@ -5,10 +5,10 @@ import { html, fixture, expect } from '@open-wc/testing';
 import { TitleSection } from '../src/dl-title';
 import '../src/dl-title';
 
-describe('`<ti-tle>`, TitleSection', () => {
+describe('`<dl-title>`, TitleSection', () => {
   it('Has specific styles', async () => {
     const el = await fixture<TitleSection>(
-      html`<ti-tle><h3>foo bar</h3></ti-tle>`
+      html`<dl-title><h3>foo bar</h3></dl-title>`
     );
 
     const slot = el.shadowRoot?.querySelector('slot');


### PR DESCRIPTION
https://www-isa.archive.org/details/democracys-library/

- header: swap z-index so words overlap over image
- file & component name updates:
  - `<arti-cle> => <dl-article>`
  - `<ti-tle> => <dl-title>`
 - article titles are now <h3> 